### PR TITLE
WIP - Faster load of Binderhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# image - sudosk/mosotf:latest
+
+# continuumio/miniconda3:4.8.2
+FROM continuumio/miniconda3@sha256:456e3196bf3ffb13fee7c9216db4b18b5e6f4d37090b31df3e0309926e98cfe2
+
+LABEL authors="sangramsahu15@gmail.com" \
+      description="Docker image containing dependencies for krassowski/multi-omics-state-of-the-field"
+
+COPY environment.yml /
+
+RUN apt-get update && \
+  conda env update -f /environment.yml -n root && \
+  conda clean -a


### PR DESCRIPTION
## Summary 

This PR is trying to address the faster load of binderhub Jupyter session.

- [x] Have a prebuid container. [`sudosk/mosotf:latest`](https://hub.docker.com/r/sudosk/mosotf/tags)
- [ ] Link the repo to dockerhub for auto-build 

If this above doesn't solves the faster loading

- [ ] Add a cron job using Github actions to build the binderhub image in every certain interval (may be 2 weeks, need to check what the availability of cache from biderhub). 